### PR TITLE
make data dir easily overridden

### DIFF
--- a/defaults/debian.yml
+++ b/defaults/debian.yml
@@ -1,0 +1,4 @@
+---
+
+postgresql_pgdata_default: /var/lib/postgresql/{{ postgresql_version }}/main
+postgresql_conf_dir_default: /etc/postgresql/{{ postgresql_version }}/main

--- a/defaults/redhat.yml
+++ b/defaults/redhat.yml
@@ -1,0 +1,4 @@
+---
+
+postgresql_pgdata_default: /var/lib/pgsql/{{ postgresql_version }}/data
+postgresql_conf_dir_default: /var/lib/pgsql/{{ postgresql_version }}/data

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,5 +1,3 @@
 ---
 
-postgresql_pgdata_default: /var/lib/postgresql/{{ postgresql_version }}/main
-postgresql_conf_dir_default: /etc/postgresql/{{ postgresql_version }}/main
 postgresql_service_name: postgresql

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,5 +1,3 @@
 ---
 
-postgresql_pgdata_default: /var/lib/pgsql/{{ postgresql_version }}/data
-postgresql_conf_dir_default: /var/lib/pgsql/{{ postgresql_version }}/data
 postgresql_service_name: postgresql-{{ postgresql_version }}


### PR DESCRIPTION
Enable the vars for data dir to be easily over-ridden. For instance when you have fast disks mounted as /data or whatever.