### PR TITLE
Fix default ~postgres/backup for local backups

### DIFF
--- a/templates/archive_wal.sh.j2
+++ b/templates/archive_wal.sh.j2
@@ -11,9 +11,9 @@ full_file=$1
 file=$2
 server=`hostname`
 
-active_dir='{{ postgresql_backup_active_dir }}'
+active_dir={{ postgresql_backup_active_dir }}
 backup_dir="{{ postgresql_backup_dir }}/current/wal"
-mutex="{{ postgresql_backup_local_dir }}/walmutex"
+mutex={{ postgresql_backup_local_dir }}/walmutex
 mailto='{{ postgresql_backup_mail_recipient }}'
 mutex_attempts=50
 

--- a/templates/backup_working_wal.sh.j2
+++ b/templates/backup_working_wal.sh.j2
@@ -4,7 +4,7 @@
 ##
 
 xlog_dir='{{ postgresql_pgdata }}/pg_xlog'
-backup_dir='{{ postgresql_backup_active_dir }}'
+backup_dir={{ postgresql_backup_active_dir }}
 mailto='{{ postgresql_backup_mail_recipient }}'
 
 active=`ls -1rtF $xlog_dir | grep -v '/$' | tail -1`

--- a/templates/scheduled_backup.sh.j2
+++ b/templates/scheduled_backup.sh.j2
@@ -7,7 +7,7 @@ server=`hostname`
 data='{{ postgresql_pgdata }}'
 dir='{{ postgresql_backup_dir }}/current'
 mailto='{{ postgresql_backup_mail_recipient }}'
-mutex='{{ postgresql_backup_local_dir }}/scheduledmutex'
+mutex={{ postgresql_backup_local_dir }}/scheduledmutex
 rotate='{{ postgresql_backup_rotate | default("True") }}'
 
 [ '{{ postgresql_backup_remote_rsync_path | default("None") }}' != 'None' ] && remote_rsync='--rsync-path={{ postgresql_backup_remote_rsync_path }}' || remote_rsync=''


### PR DESCRIPTION
The problem was that scripts ended up quoting the value
like this
mutex="~postgres/backup/walmutex"
and ~postgres did not get expanded correctly.

With this change, our wal backups started working.