### PR TITLE
Fix config for PostgreSQL < 9.3

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,6 +31,13 @@
 - name: Set conf.d include in postgresql.conf
   lineinfile: line="include_dir 'conf.d'" dest={{ postgresql_conf_dir }}/postgresql.conf backup=yes
   notify: Reload PostgreSQL
+  when: "{{ postgresql_version | version_compare('9.3', '>=') }}"
+
+
+- name: Include 25ansible_postgresql.conf in postgresql.conf
+  lineinfile: line="include 'conf.d/25ansible_postgresql.conf'" dest={{ postgresql_conf_dir }}/postgresql.conf backup=yes
+  notify: Reload PostgreSQL
+  when: "{{ postgresql_version | version_compare('9.3', '<') }}"
 
 - name: Set config options
   template: src=25ansible_postgresql.conf.j2 dest={{ postgresql_conf_dir }}/conf.d/25ansible_postgresql.conf owner=postgres group=postgres backup=yes


### PR DESCRIPTION
the include_dir option was added in version 9.3 [1], directly include
the ansible-generated config file for earlier versions

[1] https://wiki.postgresql.org/wiki/What%27s_new_in_PostgreSQL_9.3#Configuration_directive_.27include_dir.27