### PR TITLE
Fix pgdg package name for 8.4

### DIFF
--- a/files/get_repo_rpm_release.py
+++ b/files/get_repo_rpm_release.py
@@ -22,11 +22,14 @@ except urllib2.HTTPError, e:
     raise
 
 pg_version = url.split('/')[3]
-re_pattern = 'href=[\'"]pgdg-%s%s-%s-([\d+]).noarch.rpm[\'"]' % (dist, pg_version.replace('.', ''), pg_version)
+if pg_version[0] == "8" and dist != "sl":
+    re_pattern = 'href=[\'"](pgdg-%s-%s-[\d+].noarch.rpm)[\'"]' % (dist, pg_version)
+else:
+    re_pattern = 'href=[\'"](pgdg-%s%s-%s-[\d+].noarch.rpm)[\'"]' % (dist, pg_version.replace('.', ''), pg_version)
 match = re.findall(re_pattern, repo.read(), flags=re.I)
 
 assert match, "No matching %s pgdg repository packages found for version %s at %s" % (dist, pg_version, url)
 
-print max([ int(x) for x in match ])
+print match[0]
 
 sys.exit(0)

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -16,11 +16,11 @@
 # helper script to parse the directory list and figure it out.
 - name: Determine latest pgdg repository package (RedHat)
   script: get_repo_rpm_release.py http://yum.postgresql.org/{{ postgresql_version }}/{{ postgresql_pgdg_families[ansible_distribution] | default("redhat") }}/{{ postgresql_pgdg_shortfamilies[ansible_distribution] | default("rhel") }}-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}/ {{ postgresql_pgdg_dists[ansible_distribution] }}
-  register: pgdg_repo_pkg_release
+  register: pgdg_repo_pkg_name
   when: repo_pkg_installed.failed is defined and repo_pkg_installed.failed
 
 - name: Install pgdg repository package (RedHat)
-  yum: name=http://yum.postgresql.org/{{ postgresql_version }}/{{ postgresql_pgdg_families[ansible_distribution] | default("redhat") }}/{{ postgresql_pgdg_shortfamilies[ansible_distribution] | default("rhel") }}-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}/pgdg-{{ postgresql_pgdg_dists[ansible_distribution] }}{{ postgresql_version | replace('.', '') }}-{{ postgresql_version }}-{{ pgdg_repo_pkg_release.stdout.strip() }}.noarch.rpm
+  yum: name=http://yum.postgresql.org/{{ postgresql_version }}/{{ postgresql_pgdg_families[ansible_distribution] | default("redhat") }}/{{ postgresql_pgdg_shortfamilies[ansible_distribution] | default("rhel") }}-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}/{{ pgdg_repo_pkg_name.stdout.strip() }}
   when: repo_pkg_installed.failed is defined and repo_pkg_installed.failed
 
 - name: Install PostgreSQL (RedHat)


### PR DESCRIPTION
The package names for PostgreSQL 8.4 follow a slightly different naming
pattern. Fixed the matching logic in get_repo_rpm_release.py.

Also changed the script to output the whole package name, which is then
used in the install task. This is to prevent having to fiddle with jinja
filters in the install task to get the correct download url.