### PR TITLE
Allow authentication of non-system database users

### DIFF
--- a/templates/pg_hba.conf.debian.j2
+++ b/templates/pg_hba.conf.debian.j2
@@ -13,6 +13,14 @@
 local   all             postgres                                peer
 {% endif %}
 
+# Entries configured in postgresql_pg_hba_conf follow
+{% if postgresql_pg_hba_conf is defined %}
+{% for line in postgresql_pg_hba_conf %} 
+{{ line }}
+{% endfor %}
+{% endif %}
+
+# End entries configured in postgresql_pg_hba_conf follow
 {% if postgresql_pg_hba_local_socket is not defined or postgresql_pg_hba_local_socket %}
 # "local" is for Unix domain socket connections only
 local   all             all                                     peer
@@ -26,9 +34,3 @@ host    all             all             127.0.0.1/32            md5
 host    all             all             ::1/128                 md5
 {% endif %}
 
-# Entries configured in postgresql_pg_hba_conf follow
-{% if postgresql_pg_hba_conf is defined %}
-{% for line in postgresql_pg_hba_conf %} 
-{{ line }}
-{% endfor %}
-{% endif %}


### PR DESCRIPTION
Hi,

I was using you role and discovered that I always got the 'peer authentication failed' message when connecting to the database as a non-system user created with ansible's `postgresql_user`. The attached patch moves the `postgresql_pg_hba` entries up so they are matched before the peer authentication of system users.

Let me know if something about the reasoning above is incorrect and I'll see to it.

Best regards,

Pieter Lexis