### PR TITLE
postgresql option config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,4 @@ postgresql_backup_local_dir: ~postgres/backup
 postgresql_backup_active_dir: "{{ postgresql_backup_local_dir }}/active"
 postgresql_backup_mail_recipient: postgres
 postgresql_backup_rotate: true
+postgresql_option_config: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,6 +42,7 @@
 - name: Set config options
   template: src=25ansible_postgresql.conf.j2 dest={{ postgresql_conf_dir }}/conf.d/25ansible_postgresql.conf owner=postgres group=postgres backup=yes
   notify: Reload PostgreSQL
+  when: postgresql_option_config
 
 - name: Install pg_hba.conf
   template: src=pg_hba.conf.{{ ansible_os_family | lower }}.j2 dest={{ postgresql_conf_dir }}/pg_hba.conf owner=postgres group=postgres mode=0400 backup=yes


### PR DESCRIPTION
In [docker-galaxy-stable](https://github.com/bgruening/docker-galaxy-stable) ```conf.d/25ansible_postgresql.conf``` is override configuration.
So this PR to create ```conf.d/25ansible_postgresql.conf``` is optional default true to this PR does not affect other environments.