### PR TITLE
Check if postgresql_backup_remote_rsync_path is defined before using it

### DIFF
--- a/templates/archive_wal.sh.j2
+++ b/templates/archive_wal.sh.j2
@@ -17,7 +17,9 @@ mutex={{ postgresql_backup_local_dir }}/walmutex
 mailto='{{ postgresql_backup_mail_recipient }}'
 mutex_attempts=50
 
+{% if postgresql_backup_remote_rsync_path is defined %}
 [ '{{ postgresql_backup_remote_rsync_path | default("None") }}' != 'None' ] && remote_rsync='--rsync-path={{ postgresql_backup_remote_rsync_path | default("None") }}' || remote_rsync=''
+{% endif %}
 
 handler()
 {

--- a/templates/scheduled_backup.sh.j2
+++ b/templates/scheduled_backup.sh.j2
@@ -9,9 +9,9 @@ dir='{{ postgresql_backup_dir }}/current'
 mailto='{{ postgresql_backup_mail_recipient }}'
 mutex={{ postgresql_backup_local_dir }}/scheduledmutex
 rotate='{{ postgresql_backup_rotate | default("True") }}'
-
+{% if postgresql_backup_remote_rsync_path is defined %}
 [ '{{ postgresql_backup_remote_rsync_path | default("None") }}' != 'None' ] && remote_rsync='--rsync-path={{ postgresql_backup_remote_rsync_path | default("None") }}' || remote_rsync=''
-
+{% endif %}
 handler()
 {
     command=$@


### PR DESCRIPTION
This is kind of a workaround trying to fix #10, probably could be better solved adding a default value for this variable. I made it work for me but I'm not using remote rsync path and might have left something out. 