### PR TITLE
Avoid triggering handlers on each run

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,5 @@ postgresql_backup_mail_recipient: postgres
 postgresql_backup_rotate: true
 
 postgresql_archive_wal_rsync_args: '--ignore-existing -ptg --info=skip1'
+
+postgresql_service: yes

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,3 +2,4 @@
 
 - name: Reload PostgreSQL
   service: name={{ postgresql_service_name }} state=reloaded
+  when: postgresql_service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,3 +52,4 @@
 
 - name: Ensure PostgreSQL is running
   service: name={{ postgresql_service_name }} enabled=yes state=started
+  when: postgresql_service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 
 # Convenient ordering - debian.yml sets postgresql_version if it is unset,
 # which is needed by the include_vars files.
-- include: debian.yml
+- include_tasks: debian.yml
   when: ansible_os_family == "Debian"
 
 # For RedHat we use the value from defaults/main.yml
@@ -22,7 +22,7 @@
   when: postgresql_conf_dir is not defined
 
 # Needs postgresql_pgdata_dir set
-- include: redhat.yml
+- include_tasks: redhat.yml
   when: ansible_os_family == "RedHat"
 
 - name: Create conf.d
@@ -47,7 +47,7 @@
   template: src=pg_hba.conf.{{ ansible_os_family | lower }}.j2 dest={{ postgresql_conf_dir }}/pg_hba.conf owner=postgres group=postgres mode=0400 backup=yes
   notify: Reload PostgreSQL
 
-- include: backup.yml
+- include_tasks: backup.yml
   when: postgresql_backup_dir is defined
 
 - name: Ensure PostgreSQL is running

--- a/templates/25ansible_postgresql.conf.j2
+++ b/templates/25ansible_postgresql.conf.j2
@@ -3,7 +3,7 @@
 ##
 
 {% if postgresql_conf is defined %}
-{% for opt in postgresql_conf %}
+{% for opt in postgresql_conf|sort %}
 {{ opt }} = {{ postgresql_conf[opt] }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
The order of dictionary is not defined, therefore the current code causes `25ansible_postgresql.conf` be always re-generated and trigger the reload handler.