### PR TITLE
Move hardcoded value 'postgres' into variable 'postgresql_user_name'

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Role Variables
 
 ### All variables are optional ###
 
+- `postgresql_user_name`: System username to be used for PostgreSQL (default:
+  `postgres`).
+
 - `postgresql_version`: PostgreSQL version to install. On Debian-based
   platforms, the default is whatever version is pointed to by the `postgresql`
   metapackage). On RedHat-based platforms, the default is `9.4`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,5 +5,6 @@ postgresql_backup_local_dir: ~postgres/backup
 postgresql_backup_active_dir: "{{ postgresql_backup_local_dir }}/active"
 postgresql_backup_mail_recipient: postgres
 postgresql_backup_rotate: true
+postgresql_user_name: postgres
 
 postgresql_archive_wal_rsync_args: '--ignore-existing -ptg --info=skip1'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
   when: ansible_os_family == "RedHat"
 
 - name: Create conf.d
-  file: path={{ postgresql_conf_dir }}/conf.d state=directory owner=postgres group=postgres
+  file: path={{ postgresql_conf_dir }}/conf.d state=directory owner={{ postgresql_user_name }} group={{ postgresql_user_name }}
 
 - name: Set conf.d include in postgresql.conf
   lineinfile: line="include_dir 'conf.d'" dest={{ postgresql_conf_dir }}/postgresql.conf backup=yes
@@ -40,11 +40,11 @@
   when: "postgresql_version is version_compare('9.3', '<')"
 
 - name: Set config options
-  template: src=25ansible_postgresql.conf.j2 dest={{ postgresql_conf_dir }}/conf.d/25ansible_postgresql.conf owner=postgres group=postgres backup=yes
+  template: src=25ansible_postgresql.conf.j2 dest={{ postgresql_conf_dir }}/conf.d/25ansible_postgresql.conf owner={{ postgresql_user_name }} group={{ postgresql_user_name }} backup=yes
   notify: Reload PostgreSQL
 
 - name: Install pg_hba.conf
-  template: src=pg_hba.conf.{{ ansible_os_family | lower }}.j2 dest={{ postgresql_conf_dir }}/pg_hba.conf owner=postgres group=postgres mode=0400 backup=yes
+  template: src=pg_hba.conf.{{ ansible_os_family | lower }}.j2 dest={{ postgresql_conf_dir }}/pg_hba.conf owner={{ postgresql_user_name }} group={{ postgresql_user_name }} mode=0400 backup=yes
   notify: Reload PostgreSQL
 
 - include: backup.yml


### PR DESCRIPTION
Rationale: provides mechanism for overriding PostgreSQL system user.
In particular, this may be needed when used together with
[ansible-galaxy-os](https://github.com/galaxyproject/ansible-galaxy-os)
role, which provides that option (variable: postgres_user_name).

(Assumption: postgresql user name and group name are the same.)