### PR TITLE
Properly handle WAL directory in backup scripts for version >=10

### DIFF
--- a/templates/backup_working_wal.sh.j2
+++ b/templates/backup_working_wal.sh.j2
@@ -3,13 +3,13 @@
 ## This file is maintained by Ansible - CHANGES WILL BE OVERWRITTEN
 ##
 
-xlog_dir='{{ postgresql_pgdata~"/"~postgresql_version is version_compare("10", ">=") | ternary("pg_wal", "pg_xlog") }}'
+wal_dir='{{ postgresql_pgdata }}/{{ postgresql_version is version("10", ">=") | ternary("pg_wal", "pg_xlog") }}'
 backup_dir={{ postgresql_backup_active_dir }}
 mailto='{{ postgresql_backup_mail_recipient }}'
 
-active=`ls -1rtF $xlog_dir | grep -v '/$' | tail -1`
+active=`ls -1rtF $wal_dir | grep -v '/$' | tail -1`
 
-out=`scp -p $xlog_dir/$active $backup_dir/$active 2>&1`
+out=`scp -p $wal_dir/$active $backup_dir/$active 2>&1`
 ret=$?
 
 if [ $ret -ne 0 ]; then

--- a/templates/backup_working_wal.sh.j2
+++ b/templates/backup_working_wal.sh.j2
@@ -3,7 +3,7 @@
 ## This file is maintained by Ansible - CHANGES WILL BE OVERWRITTEN
 ##
 
-xlog_dir='{{ postgresql_pgdata }}/pg_xlog'
+xlog_dir='{{ postgresql_pgdata~"/"~postgresql_version is version_compare("10", ">=") | ternary("pg_wal", "pg_xlog") }}'
 backup_dir={{ postgresql_backup_active_dir }}
 mailto='{{ postgresql_backup_mail_recipient }}'
 

--- a/templates/scheduled_backup.sh.j2
+++ b/templates/scheduled_backup.sh.j2
@@ -9,7 +9,7 @@ dir='{{ postgresql_backup_dir }}/current'
 mailto='{{ postgresql_backup_mail_recipient }}'
 mutex={{ postgresql_backup_local_dir }}/scheduledmutex
 rotate='{{ postgresql_backup_rotate | default("True") }}'
-xlog_dir='{{ postgresql_version is version_compare("10", ">=") | ternary("pg_wal", "pg_xlog") }}'
+wal_dir='{{ postgresql_version is version("10", ">=") | ternary("pg_wal", "pg_xlog") }}'
 
 [ '{{ postgresql_backup_remote_rsync_path | default("None") }}' != 'None' ] && remote_rsync='--rsync-path={{ postgresql_backup_remote_rsync_path | default("None") }}' || remote_rsync=''
 
@@ -84,7 +84,7 @@ backup_started=1
 handler mkdir -p $data/wal
 
 # begin the backup
-handler rsync $remote_rsync -rptg --delete --delete-delay --exclude $xlog_dir $data/ $dir
+handler rsync $remote_rsync -rptg --delete --delete-delay --exclude $wal_dir $data/ $dir
 
 # tell postgres we're done
 psql_handler "SELECT pg_stop_backup();"

--- a/templates/scheduled_backup.sh.j2
+++ b/templates/scheduled_backup.sh.j2
@@ -9,6 +9,7 @@ dir='{{ postgresql_backup_dir }}/current'
 mailto='{{ postgresql_backup_mail_recipient }}'
 mutex={{ postgresql_backup_local_dir }}/scheduledmutex
 rotate='{{ postgresql_backup_rotate | default("True") }}'
+xlog_dir='{{ postgresql_version is version_compare("10", ">=") | ternary("pg_wal", "pg_xlog") }}'
 
 [ '{{ postgresql_backup_remote_rsync_path | default("None") }}' != 'None' ] && remote_rsync='--rsync-path={{ postgresql_backup_remote_rsync_path | default("None") }}' || remote_rsync=''
 
@@ -83,7 +84,7 @@ backup_started=1
 handler mkdir -p $data/wal
 
 # begin the backup
-handler rsync $remote_rsync -rptg --delete --delete-delay --exclude pg_xlog $data/ $dir
+handler rsync $remote_rsync -rptg --delete --delete-delay --exclude $xlog_dir $data/ $dir
 
 # tell postgres we're done
 psql_handler "SELECT pg_stop_backup();"


### PR DESCRIPTION
According to official documentation in version 10 'pg_xlog' directory was renamed to 'pg_wal'. This pull request introduces conditional template evaluation depending on PostgreSQL version being installed.

Links to documentation:
https://www.postgresql.org/docs/10/release-10.html#id-1.11.6.13.4
https://wiki.postgresql.org/wiki/New_in_postgres_10#Renaming_of_.22xlog.22_to_.22wal.22_Globally_.28and_location.2Flsn.29