### PR TITLE
Check pgdg repository package task for RHEL based distros should check pgdg-redhat-repo package

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -4,7 +4,7 @@
 # every time to check whether it's installed, so, don't do that.
 - name: Check pgdg repository package (RedHat)
   yum:
-    name: "pgdg-{{ postgresql_pgdg_dists[ansible_distribution] }}{{ postgresql_version | replace('.', '') }}"
+    name: "pgdg-redhat-repo"
   register: __postgresql_repo_pkg_installed_result
   ignore_errors: yes
 


### PR DESCRIPTION
As of 15 April 2019, there is only one repository RPM per distro, and it includes repository information for all available PostgreSQL releases.