### PR TITLE
Add postgres respository GPG key

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -13,6 +13,11 @@
   register: __postgresql_repo_pkg_installed_result
   ignore_errors: yes
 
+- name: Install repository key
+  rpm_key:
+    key: https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+    state: present
+
 - name: Install pgdg repository package (RedHat)
   yum:
     name: >-


### PR DESCRIPTION
The task "Install pgdg repository package (RedHat)" was failing with "Failed to validate GPG signature for pgdg-redhat-repo-42.0-20.noarch" error.

Importing the key from https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG fixes the issue.