### PR TITLE
Make it work with check_mode

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -24,13 +24,29 @@
   retries: 5
   delay: 5
 
+- name: Temp file for check mode
+  set_fact:
+    __temp_file_for_check_mode: "/tmp/galaxyproject_postgresql_get_installed_version_trick"
+
+- name: Create temp file for check_mode
+  ansible.builtin.copy:
+    content: ""
+    dest: "{{ __temp_file_for_check_mode }}"
+    force: yes
+    mode: '0777'
+  check_mode: no
+
 - name: Get installed version
-  command: dpkg-query -f ${Version;3} --show postgresql
+  shell: "dpkg-query -f '${Version;3}' --show postgresql"
   when: postgresql_version is not defined
   register: __postgresql_version_query_result
   changed_when: false
+  check_mode: no
+  args:
+    # Using this in order to enforce the task to be executed in check mode
+    removes: "{{ __temp_file_for_check_mode }}"
 
 - name: Set version fact
   set_fact:
-    postgresql_version: "{{ __postgresql_version_query_result.stdout.split('+') | first }}"
+    postgresql_version: "{{ __postgresql_version_query_result.stdout.split('+') | first | string }}"
   when: postgresql_version is not defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,7 +51,7 @@
   check_mode: true
   changed_when: __postgresql_include_dir_result is not changed  # yeah...
   register: __postgresql_include_dir_result
-  when: postgresql_version is version('9.3', '>=')
+  when: postgresql_version is version("9.3", '>=')
 
 - name: Set conf.d include in postgresql.conf
   lineinfile:


### PR DESCRIPTION
Ok, even with the small fix I proposed in #38, it was still not working in check_mode (because a bunch of reasons).

So this PR aims to make it work also with in `--check` (check mode). I had to set a small "hack" to make it work because neither `command` not `shell` effectively run in check_mode, so we couldn't get the current version result from them (using dpkg shell command).