### PR TITLE
new key location

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -15,7 +15,7 @@
 
 - name: Install repository key
   rpm_key:
-    key: https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+    key: https://download.postgresql.org/pub/repos/yum/keys/RPM-GPG-KEY-PGDG
     state: present
 
 - name: Install pgdg repository package (RedHat)


### PR DESCRIPTION
Key location apparently changed and the added a "keys" directory
I'm not sure if Debian is affected as well.