### PR TITLE
Add RHEL GPG key with PGDG prefix (allows installing PostgreSQL >= 11)

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -13,9 +13,14 @@
   register: __postgresql_repo_pkg_installed_result
   ignore_errors: true
 
-- name: Install repository key
+- name: Install repository key (PostgreSQL v10 and below)
   rpm_key:
     key: https://download.postgresql.org/pub/repos/yum/keys/RPM-GPG-KEY-PGDG
+    state: present
+
+- name: Install repository key (PostgreSQL v11 and above)
+  rpm_key:
+    key: https://download.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL
     state: present
 
 - name: Install pgdg repository package (RedHat)


### PR DESCRIPTION
According to https://download.postgresql.org/pub/repos/yum/keys/README.txt, there are two types of keys for RHEL: `RPM-GPG-KEY-PGDG*` and `PGDG-RPM-GPG-KEY*`.

> This directory contains keys used for signing the PostgreSQL RPMs on RHEL (and its derivatives) and Fedora.
> The keys which have the PGDG prefix are used to sign PostgreSQL 11 and above RPMs.
>
> Archived versions (v10 and below) use the RPM-GPG-KEY prefix.

The role is already adding the first kind of key to the system (see #53), but not the second. Therefore, installing newer PostgreSQL versions is not possible at the moment. This commit adds the second type of key so that newer PostgreSQL versions can be installed too.

Closes #54.