### PR TITLE
set a default postgresql timezone to UTC

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,11 @@ postgresql_pgdg_key_url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
 postgresql_pgdg_repo: "deb [signed-by={{ postgresql_pgdg_key_dest }}] http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main"
 
 postgresql_default_version: 15
+
+# Galaxy times are in UTC but postgresql can come preconfigured for a different TZ, https://github.com/galaxyproject/galaxy/issues/16021
+postgresql_conf:
+  - timezone: "UTC"
+
 postgresql_user_name: postgres
 
 postgresql_install_psycopg2: true


### PR DESCRIPTION
this prevents cutoff issues at https://github.com/galaxyproject/galaxy/issues/16021

this change seems more galaxy-centric than the rest of the role :(