### PR TITLE
Restart PostgreSQL when setting config options from 25ansible_postgresql.conf.j2

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,3 +2,5 @@
 
 - name: Reload PostgreSQL
   service: name={{ postgresql_service_name }} state=reloaded
+- name: Restart PostgreSQL
+  service: name={{ postgresql_service_name }} state=restarteed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -77,7 +77,7 @@
     group: "{{ postgresql_user_name }}"
     mode: 0644
     backup: true
-  notify: Reload PostgreSQL
+  notify: Restart PostgreSQL
 
 - name: Install pg_hba.conf
   template:


### PR DESCRIPTION
When I try to set config options to be included in 25ansible_postgresql.conf such as `listen_addresses`, reloading the PostgreSQL service does not have any impact on it. The only way to include such options is to restart the service.