### PR TITLE
Fix Debian PostgreSQL setup: create cluster if missing and target version-specific systemd unit

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -48,3 +48,8 @@
   apt:
     name: "python{{ (ansible_python.version.major == 3) | ternary('3', '') }}-psycopg2"
   when: postgresql_install_psycopg2
+
+- name: Ensure the PostgreSQL cluster exists (Debian)
+  command:
+    cmd: "pg_createcluster {{ postgresql_version }} main"
+    creates: "/etc/postgresql/{{ postgresql_version }}/main/postgresql.conf"

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -2,4 +2,8 @@
 
 postgresql_pgdata_default: /var/lib/postgresql/{{ postgresql_version }}/main
 postgresql_conf_dir_default: /etc/postgresql/{{ postgresql_version }}/main
-postgresql_service_name: postgresql
+# Target the version-specific cluster unit rather than the "postgresql" meta-service. The meta-service is a oneshot
+# that is already active when another cluster (e.g. an existing 15/main) is running, so `state=started` against it is
+# a no-op and would not start this cluster; `state=reloaded` against it would also reload every cluster on the host.
+# Using postgresql@<version>-main starts/reloads only this cluster, which is what we want for side-by-side installs.
+postgresql_service_name: "postgresql@{{ postgresql_version }}-main"


### PR DESCRIPTION
## Summary

Two related fixes for running this role against Debian/Ubuntu hosts, surfaced while
installing PostgreSQL 18 (incl. side-by-side with an existing cluster).

### 1. Ensure the Debian/Ubuntu cluster exists before configuring it

The role assumed the `postgresql-NN` package's postinst had already created the
`main` cluster via `pg_createcluster`. When that auto-creation is skipped or fails
(locale issues, `create_main_cluster=false` in `createcluster.conf`, or the config
dir already existing), `/etc/postgresql/NN/main/postgresql.conf` is never written and
the role fails with a confusing error two tasks later:

TASK [galaxyproject.postgresql : Check for conf.d include in postgresql.conf]
Destination /etc/postgresql/18/main/postgresql.conf does not exist !



Worse, the `Create conf.d` task silently creates the empty `/etc/postgresql/NN/main/`
parent directory, which then *blocks* a later `pg_createcluster` and makes the failure
sticky across re-runs.

This PR adds an explicit, idempotent cluster-creation step to `tasks/debian.yml`
(guarded by `creates:`) that runs *before* `Create conf.d`, so the cluster is always
in place before the role writes any config into it. On hosts where the cluster already
exists it is a no-op.

### 2. Target the version-specific systemd unit on Debian instead of the meta-service

On Debian, `postgresql_service_name` was the `postgresql` meta-service. That oneshot is
already `active` whenever *any* cluster is running (e.g. an existing `15/main`), so:

- `service: name=postgresql state=started` is a **no-op** and never starts the cluster
  this role is managing — the new cluster stays down after the run.
- the `Reload PostgreSQL` handler (`state=reloaded`) reloads **every** cluster on the
  host, unexpectedly touching unrelated/production clusters.

This PR changes the Debian default to `postgresql@{{ postgresql_version }}-main`,
mirroring what RedHat already does (`postgresql-{{ postgresql_version }}`). Start/enable
and reload now affect only the cluster this role manages, which also makes side-by-side
installs (e.g. 15 and 18 on one host) behave correctly.

## Changes

- `tasks/debian.yml`: add `Ensure the PostgreSQL cluster exists (Debian)` using
  `pg_createcluster {{ postgresql_version }} main` with a `creates:` guard.
- `vars/debian.yml`: `postgresql_service_name` → `postgresql@{{ postgresql_version }}-main`.

## Testing

- Fresh Debian/Ubuntu host: cluster is created, configured, and started by the role.
- Host with an existing cluster (e.g. 15/main running): installing a second version
  (18) now creates, configures, **starts** the 18 cluster on its own port, and leaves
  the existing cluster untouched (no cross-cluster reload).
- Re-runs are idempotent (cluster creation is a no-op once `postgresql.conf` exists).

## Notes / compatibility

- No change for RedHat (already version-specific).
- Single-cluster Debian hosts are unaffected in behavior; targeting the cluster unit is
  equivalent to the meta-service when only one cluster exists.